### PR TITLE
ci(github-actions): fix some errors in the Checkout step

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -26,7 +26,7 @@ jobs:
           # Just don't cache the cursed $GITHUB_TOKEN
           persist-credentials: false
           # IDK about how we should test Dangerfile changes for now.
-          repository: 'https://github.com/RecapTime/verify'
+          repository: 'RecapTime/verify'
           ref: 'main'
           # We want them all
           fetch-depth: 0


### PR DESCRIPTION
Since the whole `.github/` directory is protected through `CODEOWNERS` and branch protection is applied to admins also, let's be nice to the process.